### PR TITLE
Extract line numbers from error output

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -49,7 +49,8 @@ def coconut():
             compiled_code = compiled_file.read()
 
         SEPARATOR = "# Compiled Coconut: -----------------------------------------------------------\n\n"
-        python_code = compiled_code.split(SEPARATOR)[-1]
+        header, python_code = compiled_code.split(SEPARATOR)
+        header_len = header.count('\n') + SEPARATOR.count('\n')
 
         # Run the compiled code.
         try:
@@ -62,6 +63,8 @@ def coconut():
 
         if running_error:
             python_error_lines = extract_trace_py(output_text)
+            # Offset line number by length of coconut header
+            python_error_lines = [line_num-header_len for line_num in python_error_lines]
         else:
             # Store output from the run
             output_text = proc.stdout.decode('utf-8')

--- a/app/app.py
+++ b/app/app.py
@@ -69,8 +69,10 @@ def coconut():
             output_text = proc.stdout.decode('utf-8')
         else:
             python_error = extract_trace_py(output_text, header_len)
+            output_text = python_error['error']
     else:
         coconut_error = extract_trace_coco(output_text)
+        output_text = coconut_error['error']
 
     # Remove temporary file that stored the code
     subprocess.run(["rm", filename])

--- a/app/trace.py
+++ b/app/trace.py
@@ -1,0 +1,66 @@
+TRACEBACK_ID = 'Traceback (most recent call last):'
+PARSE_ERROR_ID = 'CoconutParseError: parsing failed'
+
+def extract_trace_py(output):
+    """Extracts info from python trace output
+    Returns line numbers of errors.
+    """
+    capture = False
+    tracebacks = []
+    curr = {}
+
+    lines = output.split('\n')
+    for index, line in enumerate(lines):
+        if TRACEBACK_ID in line:
+            capture = True
+        elif capture and line.startswith(' '):
+            if line.lstrip().startswith('File'):
+                # Line with file, line number, and context
+                line = line.strip()
+                fname, line_num, context = [s.strip() for s in line.split(',')]
+                # Next line is the called function
+                call = lines[index+1].strip()
+                # Update current trace
+                curr['file'] = fname.lstrip('File ')[1:-1]
+                curr['line'] = int(line_num.lstrip('line '))
+                curr['context'] = context.lstrip('in ')
+                curr['call'] = call
+                # Offset line number by length of coconut header
+                curr['line'] -= 637
+        elif capture:
+            # Line with error
+            curr['error'] = line
+            tracebacks.append(curr)
+            curr = {}
+            break
+
+    # Return list of line numbers
+    return [traceback['line'] for traceback in tracebacks]
+
+def extract_trace_coco(output):
+    """Extracts info from coconut parse error output
+    Returns line numbers of errors.
+    """
+    capture = False
+    tracebacks = []
+    curr = {}
+
+    lines = output.split('\n')
+    for line in lines:
+        if PARSE_ERROR_ID in line:
+            capture = True
+            line_num = line.lstrip(PARSE_ERROR_ID).strip()[1:-1]
+            curr['line'] = int(line_num.lstrip('line '))
+        elif capture and line.startswith('  '):
+            # Line with called function
+            line = line.strip()
+            curr['call'] = line
+        elif capture:
+            # Line with error
+            curr['error'] = line
+            tracebacks.append(curr)
+            curr = {}
+            break
+
+    # Return list of line numbers
+    return [traceback['line'] for traceback in tracebacks]

--- a/app/trace.py
+++ b/app/trace.py
@@ -25,8 +25,6 @@ def extract_trace_py(output):
                 curr['line'] = int(line_num.lstrip('line '))
                 curr['context'] = context.lstrip('in ')
                 curr['call'] = call
-                # Offset line number by length of coconut header
-                curr['line'] -= 637
         elif capture:
             # Line with error
             curr['error'] = line

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -129,17 +129,14 @@ class InterpreterTestCase(unittest.TestCase):
 
     def test_parse_error(self):
         response = self.get_code_response(PARSE_ERROR_CODE)
-        print(response.data)
         assert PARSE_ERROR_OUTPUT in response.data
 
     def test_syntax_error(self):
         response = self.get_code_response(SYNTAX_ERROR_CODE)
-        print(response.data)
         assert SYNTAX_ERROR_OUTPUT in response.data
 
     def test_traceback(self):
         response = self.get_code_response(TRACEBACK_CODE)
-        print(response.data)
         assert TRACEBACK_OUTPUT in response.data
 
 if __name__ == "__main__":

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -65,6 +65,14 @@ def size(Node(l, r)) = size(l) + size(r)
 size(Node(Empty(), Leaf(10))) == 1
 '''
 
+PARSE_ERROR_CODE = '1 +'
+
+PARSE_ERROR_OUTPUT = b'"coconutErrorLines": [\n    1\n  ]'
+
+TRACEBACK_CODE = '1 + "A"'
+
+TRACEBACK_OUTPUT = b'"pythonErrorLines": [\n    1\n  ]'
+
 class MockDevice():
     """
     A mock device to temporarily suppress output to stdout, so that
@@ -114,6 +122,14 @@ class InterpreterTestCase(unittest.TestCase):
         '''DATA_TYPES_CODE does not work with Coconut's parse function.'''
         response = self.get_code_response(DATA_TYPES_CODE)
         self.assertEqual(response.status_code, 200)
+
+    def test_parse_error(self):
+        response = self.get_code_response(PARSE_ERROR_CODE)
+        assert PARSE_ERROR_OUTPUT in response.data
+
+    def test_traceback(self):
+        response = self.get_code_response(TRACEBACK_CODE)
+        assert TRACEBACK_OUTPUT in response.data
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -67,11 +67,15 @@ size(Node(Empty(), Leaf(10))) == 1
 
 PARSE_ERROR_CODE = '1 +'
 
-PARSE_ERROR_OUTPUT = b'"coconutErrorLines": [\n    1\n  ]'
+PARSE_ERROR_OUTPUT = b'"coconutError": {\n    "call": "1 +", \n    "error": "CoconutParseError: parsing failed", \n    "line": 1\n  }'
+
+SYNTAX_ERROR_CODE = '1 + "A'
+
+SYNTAX_ERROR_OUTPUT = b'"coconutError": {\n    "call": "1 + \\"A", \n    "error": "CoconutSyntaxError: linebreak in non-multiline string", \n    "line": 1\n  }'
 
 TRACEBACK_CODE = '1 + "A"'
 
-TRACEBACK_OUTPUT = b'"pythonErrorLines": [\n    1\n  ]'
+TRACEBACK_OUTPUT = b'"pythonError": {\n    "call": "1 + \\"A\\"", \n    "error": "TypeError: unsupported operand type(s) for +: \'int\' and \'str\'", \n    "line": 1\n  }'
 
 class MockDevice():
     """
@@ -125,10 +129,17 @@ class InterpreterTestCase(unittest.TestCase):
 
     def test_parse_error(self):
         response = self.get_code_response(PARSE_ERROR_CODE)
+        print(response.data)
         assert PARSE_ERROR_OUTPUT in response.data
+
+    def test_syntax_error(self):
+        response = self.get_code_response(SYNTAX_ERROR_CODE)
+        print(response.data)
+        assert SYNTAX_ERROR_OUTPUT in response.data
 
     def test_traceback(self):
         response = self.get_code_response(TRACEBACK_CODE)
+        print(response.data)
         assert TRACEBACK_OUTPUT in response.data
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Prep for #40

TODO
- [x] Transform python line number with coconut header offset
- [x] Return error message from traceback
- [x] Support all coconut errors (e.g. `CoconutSyntaxError`)