### PR TITLE
Fix circleci

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -27,10 +27,13 @@ def test(coverage=False):
         os.execvp(sys.executable, [sys.executable] + sys.argv)
     import unittest
     import xmlrunner
+    import sys
     tests = unittest.TestLoader().discover('tests')
     # run tests with unittest-xml-reporting and output to $CIRCLE_TEST_REPORTS on CircleCI or
     # test-reports locally
-    xmlrunner.XMLTestRunner(output=os.environ.get('CIRCLE_TEST_REPORTS', 'test-reports')).run(tests)
+    test_runner = xmlrunner.XMLTestRunner(output=os.environ.get('CIRCLE_TEST_REPORTS', 'test-reports'))
+    results = test_runner.run(tests)
+    
     if COV:
         COV.stop()
         COV.save()
@@ -41,6 +44,10 @@ def test(coverage=False):
         COV.html_report(directory=covdir)
         print('HTML version: file://%s/index.html' % covdir)
         COV.erase()
+
+    # exit with the exit code based on whether the tests fail or not.
+    sys.exit(not results.wasSuccessful())
+    
 
 if __name__ == '__main__':
     manager.run()

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -139,5 +139,8 @@ class InterpreterTestCase(unittest.TestCase):
         response = self.get_code_response(TRACEBACK_CODE)
         assert TRACEBACK_OUTPUT in response.data
 
+    def test_fail(self):
+        assert False
+    
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Test if the circleci fails when the tests actually are not passed. The issue was from the fact that running tests did not give the correct exit code.